### PR TITLE
Bandaid fix for AI leader cap issues

### DIFF
--- a/common/on_actions/strpulse.txt
+++ b/common/on_actions/strpulse.txt
@@ -42,7 +42,7 @@ on_five_year_pulse = {
 
 on_five_year_pulse_country = {
 	events = {
-		starnet.300
+		# starnet.300
 	}
 }
 


### PR DESCRIPTION
Won't stop the AI from building lots of empty science ships, and the only way I can think of is to revert the AI alloy expenditures to mostly vanilla checks (no time-gating stuff). While the vanilla AI will eventually run into the same problem, it's much less obvious as it won't have 3-4 empty science ships idling in the capital.